### PR TITLE
Remove not past scheduled time validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,8 @@ group :development do
   gem 'coveralls'
 
   gem 'shotgun'
+  gem 'pry'
+  gem 'pry-byebug'
 
   # gem 'guard'
   # gem 'guard-minitest'

--- a/lib/sidekiq/cron/job.rb
+++ b/lib/sidekiq/cron/job.rb
@@ -17,7 +17,6 @@ module Sidekiq
         enqueue = false
         enqueue = Sidekiq.redis do |conn|
           status == "enabled" &&
-            not_past_scheduled_time?(time) &&
             not_enqueued_after?(time) &&
             conn.zadd(job_enqueued_key, formated_enqueue_time(time), formated_last_time(time))
         end
@@ -539,12 +538,6 @@ module Sidekiq
         else
           [*args]     # cast to string array
         end
-      end
-
-      def not_past_scheduled_time?(current_time)
-        last_cron_time = Rufus::Scheduler::CronLine.new(@cron).previous_time(current_time)
-        return false if (current_time.to_i - last_cron_time.to_i) > 60
-        true
       end
 
       # Redis key for set of all cron jobs

--- a/test/unit/job_test.rb
+++ b/test/unit/job_test.rb
@@ -806,11 +806,6 @@ describe "Cron Job" do
       refute Sidekiq::Cron::Job.new(@args).should_enque? @time + 235
     end
 
-    it "should not enqueue jobs that are past" do
-      assert Sidekiq::Cron::Job.new(@args.merge(cron: "*/1 * * * *")).should_enque? @time
-      refute Sidekiq::Cron::Job.new(@args.merge(cron: "0 1,13 * * *")).should_enque? @time
-    end
-
     it 'doesnt skip enqueuing if job is resaved near next enqueue time' do
       job = Sidekiq::Cron::Job.new(@args)
       assert job.test_and_enque_for_time!(@time), "should enqueue"


### PR DESCRIPTION
There is an issue with this gem where sometimes scheduled jobs
don't start, randomly.

The underlying problem here is that the gem polls jobs every minute
and checks if it's the correct time to run each job. This process sometimes
takes more than a minute to check all crons ending up not triggering them
since it's already past the cron time.

After investigating, the conclusion was that we can remove the
`not_past_scheduled_last_time?` validation and rely only on the
`not_enqueued_after?` because it already ensures that no job is
scheduled more than once.