### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM ruby:2.3.1
+MAINTAINER Joao Serra <joaopfserra@gmail.com>
+
+RUN apt-get update && \
+    apt-get install -y --force-yes \
+            curl \
+            git \
+            wget \
+            libpq-dev && \
+    apt-get autoremove -y --force-yes && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ENV DOCKERIZE_VERSION v0.2.0
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+RUN gem install bundler
+
+ENV APP_HOME /sidekiq-cron
+RUN mkdir $APP_HOME
+WORKDIR $APP_HOME
+
+ADD Gemfile* $APP_HOME/
+
+ENV BUNDLE_GEMFILE=$APP_HOME/Gemfile \
+  BUNDLE_JOBS=2 \
+  BUNDLE_PATH=/bundle
+
+RUN bundle install
+
+ADD . $APP_HOME

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '2'
+services:
+  common:
+    build:
+      context: .
+    image: sidekiq-cron-test
+    environment: &environment
+    - REDIS_URL=redis://redis.test:6379/0
+    dns:
+    - 8.8.8.8
+    - 8.8.4.4
+  redis:
+    image: redis
+  tests:
+    image: sidekiq-cron-test
+    environment: *environment
+    links:
+    - redis:redis.test
+    depends_on:
+    - common
+    command: dockerize -wait tcp://redis.test:6379 -timeout 60s rake test


### PR DESCRIPTION
Added Dockerfile and docker-compose.yml to the project.

It is now possible to run the project tests in a docker environment with
`docker-compose run tests`